### PR TITLE
Add  the __try statement

### DIFF
--- a/src/cmd/compile/internal/syntax/scanner.go
+++ b/src/cmd/compile/internal/syntax/scanner.go
@@ -368,10 +368,10 @@ func (s *scanner) isIdentRune(c rune, first bool) bool {
 // hash is a perfect hash function for keywords.
 // It assumes that s has at least length 2.
 func hash(s []byte) uint {
-	return (uint(s[0])<<4 ^ uint(s[1]) + uint(len(s))) & uint(len(keywordMap)-1)
+	return ((uint(s[0]) << 4) ^ (uint(s[1]) + uint(len(s)))) & uint(len(keywordMap)-1)
 }
 
-var keywordMap [1 << 6]token // size must be power of two
+var keywordMap [1 << 8]token // size must be power of two
 
 func init() {
 	// populate keywordMap

--- a/src/cmd/compile/internal/syntax/tokens.go
+++ b/src/cmd/compile/internal/syntax/tokens.go
@@ -62,6 +62,7 @@ const (
 	_Select
 	_Struct
 	_Switch
+	_Try
 	_Type
 	_Var
 
@@ -134,6 +135,7 @@ var tokstrings = [...]string{
 	_Select:      "select",
 	_Struct:      "struct",
 	_Switch:      "switch",
+	_Try:         "__try",
 	_Type:        "type",
 	_Var:         "var",
 }

--- a/src/example/try.go
+++ b/src/example/try.go
@@ -1,0 +1,27 @@
+package main
+
+import "fmt"
+import "errors"
+
+func g() error {
+	return errors.New("OMG")
+}
+
+func f() error {
+	fmt.Println("before try")
+	__try g() // MAGIC!
+	fmt.Println("not reached")
+	return nil
+}
+
+func main() {
+	err := f()
+	fmt.Println("done, error: ", err)
+}
+
+// Expected output:
+//
+// $ go run example/try.go
+// before try
+// done, error:  OMG
+//

--- a/src/example/try.go
+++ b/src/example/try.go
@@ -3,18 +3,24 @@ package main
 import "fmt"
 import "errors"
 
-func g() error {
-	return errors.New("OMG")
+func h() (int, error) {
+	return 0, errors.New("OMG")
 }
 
-func f() error {
-	fmt.Println("before try")
-	__try g() // MAGIC!
+func g() (__err error) {
+	x := __try h() // assignment
+	fmt.Println("not reached", x)
+	return
+}
+
+func f() (__err error) {
+	__try g() // statement
 	fmt.Println("not reached")
-	return nil
+	return
 }
 
 func main() {
+	fmt.Println("start")
 	err := f()
 	fmt.Println("done, error: ", err)
 }
@@ -22,6 +28,6 @@ func main() {
 // Expected output:
 //
 // $ go run example/try.go
-// before try
+// start
 // done, error:  OMG
 //


### PR DESCRIPTION
Proof-of-concept of the `try` keyword.

`__try f()`  transforms into `__err = f(); if __err != nil { return }`.
`x, y := __try f()`  transforms into `x, y, __err := f(); if __err != nil { return }`.

Basically it adds `if __err != nil { return }` after a statement with `__try`.
Only block-level assignments and call statements are supported.
`__err` is a special name for function return type.

```
func f() (__err error) { 
	__try g()
	return
}
```

This patch only changes the compiler. 
Tools like `fmt` and `vet` require additional changes in src/go/parser.